### PR TITLE
build: bump serde_json dependency to 1.0.38

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ serde = "1.0"
 stacker = "0.1"
 
 [dev-dependencies]
-serde_json = { version = "1.0", features = ["unbounded_depth"] }
+serde_json = { version = "1.0.38", features = ["unbounded_depth"] }


### PR DESCRIPTION
Because the feature has been added only in that release.