### PR TITLE
Update stacker version to 0.1.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ travis-ci = { repository = "dtolnay/serde-stacker" }
 
 [dependencies]
 serde = "1.0"
-stacker = "0.1"
+stacker = "0.1.8"
 
 [dev-dependencies]
 serde_json = { version = "1.0.38", features = ["unbounded_depth"] }


### PR DESCRIPTION
## Abstract

This PR updates the `stacker` dependency to address a bug experienced when compiling for some platforms, e.g. `wasm32-unknown-unknown`.