### PR TITLE
Adapt `de:is_human_readable`

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -309,6 +309,10 @@ where
         let param = Param::new(self.red_zone, self.stack_size);
         self.de.deserialize_identifier(Visitor::new(visitor, param))
     }
+
+    fn is_human_readable(&self) -> bool {
+        self.de.is_human_readable()
+    }
 }
 
 struct Visitor<V> {


### PR DESCRIPTION
The default implementation of `serde::de::Deserializer::is_human_readable` [is `true`](https://github.com/serde-rs/serde/blob/33438850a6a8b0a3550619a60885cfc6f224e53f/serde/src/de/mod.rs#L1214-L1216).
This threads the implementation of `is_human_readable` in the `serde_stacker` `Deserializer` through that of its generic parameter, to allow setting it to something else therein.

I've checked this is the last missing optional member in `Deserializer`